### PR TITLE
fix: 修复 GitHub Pages 部署后 hero section 背景 SVG 无法显示的问题

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,12 @@
 import type { NextConfig } from "next";
 
+const isProd = process.env.NODE_ENV === 'production';
+const basePath = isProd ? '/Polyplot-frontend' : '';
+
 const nextConfig: NextConfig = {
   output: 'export',
-  basePath: process.env.NODE_ENV === 'production' ? '/Polyplot-frontend' : '',
+  basePath,
+  assetPrefix: basePath,
   images: {
     unoptimized: true,
     remotePatterns: [

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,12 @@
 import MarketList from '@/components/home/MarketList';
 import { NarrativeCardProps } from '@/components/home/NarrativeCard';
 
+// 获取资源路径（考虑 basePath）
+const getAssetPath = (path: string) => {
+  const basePath = process.env.NODE_ENV === 'production' ? '/Polyplot-frontend' : '';
+  return `${basePath}${path}`;
+};
+
 // 模拟市场数据
 const mockMarkets: NarrativeCardProps[] = [
   {
@@ -160,7 +166,7 @@ export default function Home() {
         className="border-b border-border-primary"
         style={{
           backgroundColor: '#0f0f0f',
-          backgroundImage: `url('/topography.svg')`,
+          backgroundImage: `url('${getAssetPath('/topography.svg')}')`,
           backgroundRepeat: 'repeat',
           backgroundSize: 'auto',
         }}


### PR DESCRIPTION
- 在 next.config.ts 中添加 assetPrefix 配置
- 在 page.tsx 中创建 getAssetPath 辅助函数处理资源路径
- 确保 SVG 背景在 production 环境下使用正确的 basePath